### PR TITLE
Replace bcryptjs with bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "bcryptjs": "^3.0.2",
         "cloudinary": "^1.41.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -92,15 +91,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "type": "commonjs",
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^3.0.2",
     "cloudinary": "^1.41.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,4 +1,4 @@
-const bcrypt = require('bcryptjs');
+const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const { generateAccessToken, generateRefreshToken } = require('../utils/jwt');


### PR DESCRIPTION
## Summary
- standardize password hashing to use `bcrypt`
- remove `bcryptjs` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_687a1ee75b408332ba4adda341952a25