### PR TITLE
Refactor body validation into reusable middleware

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -4,11 +4,6 @@ exports.register = async (req, res, next) => {
     try {
         const { username, email, password } = req.body;
 
-        // Validate required fields
-        if (!username || !email || !password) {
-            return res.status(400).json({ message: 'All fields are required' });
-        }
-
         // Register the user
         await authService.register({ username, email, password });
 
@@ -22,11 +17,6 @@ exports.register = async (req, res, next) => {
 exports.login = async (req, res, next) => {
     try {
         const { email, password } = req.body;
-
-        // Validate required fields
-        if (!email || !password) {
-            return res.status(400).json({ message: 'All fields are required' });
-        }
 
         // Authenticate user and get tokens
         const { accessToken, refreshToken } = await authService.login({ email, password });

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -50,9 +50,6 @@ exports.getAllUsers = async (req, res, next) => {
 exports.createUser = async (req, res, next) => {
     try {
         const { username, email, password, role } = req.body;
-        if (!username || !email || !password) {
-            return res.status(400).json({ message: 'Missing required fields' });
-        }
 
         const user = await userService.createUser({
             username,
@@ -86,7 +83,6 @@ exports.updateUser = async (req, res, next) => {
 exports.deleteUser = async (req, res, next) => {
     try {
         const { userId } = req.body;
-        if (!userId) return res.status(400).json({ message: 'userId is required' });
         const deleted = await userService.deleteUser(userId);
         if (!deleted) return res.status(404).json({ message: 'User not found' });
         res.json({ message: 'User deleted successfully' });

--- a/middlewares/validationMiddleware.js
+++ b/middlewares/validationMiddleware.js
@@ -1,0 +1,34 @@
+const defaultIsEmpty = (value) => {
+    if (value === undefined || value === null) {
+        return true;
+    }
+
+    if (typeof value === 'string') {
+        return value.trim() === '';
+    }
+
+    return false;
+};
+
+exports.validateBody = (requiredFields, options = {}) => {
+    if (!Array.isArray(requiredFields)) {
+        throw new TypeError('requiredFields must be an array of field names');
+    }
+
+    const { isEmpty = defaultIsEmpty } = options;
+
+    return (req, res, next) => {
+        const missingFields = requiredFields.filter((field) => {
+            const value = req.body?.[field];
+            return isEmpty(value);
+        });
+
+        if (missingFields.length) {
+            return res.status(400).json({
+                message: `Missing required fields: ${missingFields.join(', ')}`,
+            });
+        }
+
+        next();
+    };
+};

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/authController');
+const { validateBody } = require('../middlewares/validationMiddleware');
 const passport = require('../config/passport');
 const jwt = require('jsonwebtoken');
 
-router.post('/register', authController.register);
+router.post('/register', validateBody(['username', 'email', 'password']), authController.register);
 
-router.post('/login', authController.login);
+router.post('/login', validateBody(['email', 'password']), authController.login);
 
 router.post('/refresh-token', authController.refreshAccessToken);
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const userController = require('../controllers/userController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const upload = require('../middlewares/upload'); // 👈 Đặt ở đây mới đúng
+const { validateBody } = require('../middlewares/validationMiddleware');
 const { userLimiter } = require('../middlewares/rateLimiters');
 
 router.get('/hello', userController.getHello);
@@ -18,11 +19,11 @@ router.get('/', userLimiter, userController.getAllUsers);
 
 router.get('/profile', authMiddleware, userController.getProfile);
 
-router.post('/', upload.single('avatar'), userController.createUser);
+router.post('/', validateBody(['username', 'email', 'password']), upload.single('avatar'), userController.createUser);
 
 router.put('/:id', upload.single('avatar'), userController.updateUser);
 
-router.delete('/', userController.deleteUser);
+router.delete('/', validateBody(['userId']), userController.deleteUser);
 
 router.get('/:id', authMiddleware, userController.getUserById);
 


### PR DESCRIPTION
## Summary
- add a reusable `validateBody` middleware to centralize required field validation
- remove duplicate input checks from the auth and user controllers
- apply the middleware across auth and user routes for consistent request handling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de2c6aad448320b9e653ad0d4d3d36